### PR TITLE
Raise error if user selects a complex region

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@
 
 This is a plugin for TinyMCE 5 that allows users to specify what language their text is written in. The plugin wraps
  the desired text in `span` tags with a `lang` attribute for the specified language. Unspecified text is assumed to be
-  written in the page's language. This helps the resulting text comply with WCAG 2.0 3.1.2 Language of Parts: "The
-   human language of each passage or phrase in the content can be programmatically determined..."
+ written in the page's language. This helps the resulting text comply with WCAG 2.0 3.1.2 Language of Parts: "The
+ human language of each passage or phrase in the content can be programmatically determined..."
+   
+The plugin is intended for use where a few words of a different language are embedded in a passage of some other
+ language. It also works when you need to change the language of the entire passage, but not as well. For best results,
+ don’t select any text and just change in and out of different language modes while typing.
   
 # Installation
 
@@ -28,7 +32,7 @@ Then you can use the plugin just like one of TinyMCE's builtin plugins. When con
 `extended_valid_elements: 'span[lang|id] -span'`
 
 # Caveats
-- One known limitation is that you can’t select and change the language of existing text in a list. (An error will be
- raised to the user to try another method of setting the language instead.)
+- One known limitation is that you can't select and change the language of text that goes across multiple HTML tags
+ (besides formatting). An error will be raised to the user.
 - There wasn’t a TinyMCE-endorsed way of changing the button text, so we directly modify the `innerText` of the button
  node. I’m not sure how well this will work with internationalization and non-default styling.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This is a plugin for TinyMCE 5 that allows users to specify what language their 
  written in the page's language. This helps the resulting text comply with WCAG 2.0 3.1.2 Language of Parts: "The
  human language of each passage or phrase in the content can be programmatically determined..."
    
-The plugin is intended for use where a few words of a different language are embedded in a passage of some other
- language. It also works when you need to change the language of the entire passage, but not as well. For best results,
- don’t select any text and just change in and out of different language modes while typing.
+The plugin is intended for use as you are creating a new passage. It also works when you need to change the language of
+ an existing passage, but not as well (see below Caveats section for details). For best results, don’t select any text
+ and just change in and out of different language modes while typing.
   
 # Installation
 
@@ -32,7 +32,10 @@ Then you can use the plugin just like one of TinyMCE's builtin plugins. When con
 `extended_valid_elements: 'span[lang|id] -span'`
 
 # Caveats
+- The repo currently doesn't contain any unit tests due to how specific TinyMCE's testing framework is to itself. It
+ has only been tested manually so far.
 - One known limitation is that you can't select and change the language of text that goes across multiple HTML tags
- (besides formatting). An error will be raised to the user.
+ (besides formatting). An error will be raised to the user. You can select and change the language of anything
+ smaller than a paragraph, provided the paragraph does not contain any language spans inside of it already.
 - There wasn’t a TinyMCE-endorsed way of changing the button text, so we directly modify the `innerText` of the button
  node. I’m not sure how well this will work with internationalization and non-default styling.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce-language-selector",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A plugin for TinyMCE 5 that allows the user to specify if text is written in a foreign language and in which language.",
   "main": "tinymce-language-selector/plugin.js",
   "scripts": {

--- a/tinymce-language-selector/plugin.js
+++ b/tinymce-language-selector/plugin.js
@@ -29,9 +29,9 @@ tinymce.PluginManager.add('language', function(editor) {
         if (parentSpan.lang) {
           insertedText = `</span>${insertedText}<span lang="${parentSpan.lang}">`;
         } else {
-          insertedText = `</span>${insertedText}<span>`
+          insertedText = `</span>${insertedText}<span>`;
         }
-        currentNode = selectedNode
+        currentNode = selectedNode;
         while (currentNode !== parentSpan) { // close out old tags and create new ones at the end of inserted content
           insertedText = `</${currentNode.nodeName.toLowerCase()}>${insertedText}<${currentNode.nodeName.toLowerCase()}>`;
           currentNode = currentNode.parentNode;
@@ -74,19 +74,28 @@ tinymce.PluginManager.add('language', function(editor) {
       }
     }
     return selectedLang;
-  }
+  };
 
   const openDialog = (buttonApi) => {
     const selectedNode = editor.selection.getNode();
-    if (['OL', 'UL'].includes(selectedNode.nodeName)) {
+    const selectionStartNode = editor.selection.getStart();
+    const selectionEndNode = editor.selection.getEnd();
+    const listTags = ['OL', 'UL'];
+    const formatTags = ['B', 'U', 'I', 'STRONG', 'EM'];
+    // Inserting a span across multiple tags (excluding formatting) doesn't work.
+    if ((selectionStartNode !== selectionEndNode &&
+        !formatTags.includes(selectionEndNode.nodeName) &&
+        !formatTags.includes(selectionStartNode.nodeName)) ||
+        listTags.includes(selectedNode.nodeName)) {
       editor.notificationManager.open({
-        text: 'You cannot change the language of a list. Set the language first and then create the list.',
+        text: 'The region that you have selected is too complex. Try selecting smaller regions, or trying changing' +
+            ' the language first and then typing your text as desired.',
         type: 'error',
       });
       return;
     }
     const selectedLang = getSelectedLanguage(editor);
-    const currentLang = selectedLang ? selectedLang : BROWSER_DEFAULT;
+    const currentLang = selectedLang || BROWSER_DEFAULT;
     editor.windowManager.open({
       title: 'Language plugin',
       body: {

--- a/tinymce-language-selector/plugin.js
+++ b/tinymce-language-selector/plugin.js
@@ -84,11 +84,11 @@ tinymce.PluginManager.add('language', function(editor) {
     const formatTags = ['B', 'U', 'I', 'STRONG', 'EM'];
     // Inserting a span across multiple tags (excluding formatting) doesn't work.
     if ((selectionStartNode !== selectionEndNode &&
-        !formatTags.includes(selectionEndNode.nodeName) &&
-        !formatTags.includes(selectionStartNode.nodeName)) ||
+        !formatTags.includes(selectionStartNode.nodeName) &&
+        !formatTags.includes(selectionEndNode.nodeName)) ||
         listTags.includes(selectedNode.nodeName)) {
       editor.notificationManager.open({
-        text: 'The region that you have selected is too complex. Try selecting smaller regions, or trying changing' +
+        text: 'The region that you have selected is too complex. Try selecting smaller regions, or try changing' +
             ' the language first and then typing your text as desired.',
         type: 'error',
       });


### PR DESCRIPTION
If a user selects a complex region, it's possible that there will be embedded span tags inside. Changing the language of this entire region will result in nested span tags, which will cause the language to be incorrect inside the nestings.
<img width="1040" alt="Screen Shot 2020-01-31 at 11 48 15 AM" src="https://user-images.githubusercontent.com/29314630/73557657-9902e480-441f-11ea-8ca4-21f77e9f54e5.png">
