### PR TITLE
build: Don't branch or tag this in the named release

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,7 +14,6 @@ metadata:
       icon: "Article"
   annotations:
     openedx.org/arch-interest-groups: "angonz"
-    openedx.org/release: "master"
 spec:
   owner: user:angonz
   type: 'library'


### PR DESCRIPTION
We only branch and tag top-level backend services, frontend apps, and non-default Open edX plugins. This, on the other hand, is an npm package that gets installed into a few frontend apps. We shouldn't tag it, because its `release/ulmo` branch is not guaranteed to line up with the tinymce-language-selector version installed by the `release/ulmo` branches of the frontend apps.


After merging, we should delete the `release/ulmo` branch.

@angonz , @feanil , @farhaanbukhsh 